### PR TITLE
Improve readline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,24 @@
         <java.version>11</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
+        <junit-jupiter.version>5.4.2</junit-jupiter.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/util/IOUtil.java
+++ b/src/main/java/util/IOUtil.java
@@ -5,8 +5,6 @@ import exception.EmptyRequestException;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
 
 public class IOUtil {
@@ -28,34 +26,22 @@ public class IOUtil {
     }
 
     public static String readLine(InputStream in) throws IOException {
-        List<Byte> list = new ArrayList<>();
-
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
         while (true) {
-            byte b = (byte) in.read();
-
+            int b = in.read();
             if (b == -1) {
                 throw new EmptyRequestException();
-            }
-
-            list.add(b);
-
-            int size = list.size();
-            if (2 <= size) {
-                char cr = (char) list.get(size - 2).byteValue();
-                char lf = (char) list.get(size - 1).byteValue();
-
-                if (cr == '\r' && lf == '\n') {
-                    break;
+            } else if (b == '\r') {
+                b = in.read();
+                if (b == '\n') {
+                    return out.toString("UTF-8");
+                } else if (b == -1) {
+                    throw new EmptyRequestException();
                 }
+                out.write('\r');
             }
+            out.write(b);
         }
-
-        byte[] buffer = new byte[list.size() - 2]; // CRLF の分減らす
-        for (int i = 0; i < list.size() - 2; i++) {
-            buffer[i] = list.get(i);
-        }
-
-        return new String(buffer, UTF_8);
     }
 
     public static InputStream toInputStream(String string) {

--- a/src/test/java/util/IOUtilTest.java
+++ b/src/test/java/util/IOUtilTest.java
@@ -1,0 +1,33 @@
+package util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import exception.EmptyRequestException;
+
+public class IOUtilTest {
+
+    @Test
+    void readLine() throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream("foo\r\nbar".getBytes());
+        String line = IOUtil.readLine(in);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        in.transferTo(out);
+        assertAll(() -> {
+            assertEquals("foo", line);
+            assertEquals("bar", out.toString());
+        });
+    }
+
+    @Test
+    void readLine_not_contains_crlf() throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream("foobar".getBytes());
+        assertThrows(EmptyRequestException.class, () -> {
+            IOUtil.readLine(in);
+        });
+    }
+}


### PR DESCRIPTION
HTTPサーバー作り、良いですね！

`List`を使うとboxing, unboxingが発生するのでプリミティブ値を大量に扱う場合は配列がオススメです。
IO周りだと`ByteArrayInputStream` `ByteArrayOutputStream`が使えます。

というわけで自分ならこんな感じで書くかな、というコードをPRしました！
マージするもよし、マージせずにクローズするもよし、お任せします！